### PR TITLE
[gitgutter] Fix gitgutter sign column

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -169,3 +169,5 @@ nnoremap <silent> <leader>d :GitGutterToggle<cr>
 
 " Set highlight group sign column (no color)
 highlight SignColumn NONE
+
+let g:gitgutter_highlight_lines=1

--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -166,3 +166,6 @@ let g:ale_lint_on_enter = 0
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let g:gitgutter_enabled=1
 nnoremap <silent> <leader>d :GitGutterToggle<cr>
+
+" Set highlight group sign column (no color)
+highlight SignColumn NONE


### PR DESCRIPTION
## Issue
![image](https://user-images.githubusercontent.com/34672141/103173610-6d8eb100-489f-11eb-934a-235b89fbc2ee.png)


Reference:
https://github.com/airblade/vim-gitgutter/blob/bf813bb99070c22c0a462d79f5072adfb391e4e1/README.mkd

```
> Why are the colours in the sign column weird?

Your colorscheme is configuring the SignColumn highlight group weirdly. Please see the section above on customising the sign column.
```